### PR TITLE
Added support for multiple kernel versions and Arch Linux as a tested distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,22 +46,26 @@
 
 ### Tested Linux Distributions:
 
-- Raspberry Pi OS (12-02-2020) (ARM 32 bit) (kernel 5.4)
-
-- LMDE 4 (Linux Mint based on Debian) (kernel 4.19)
+- Arch Linux (kernel 5.4)
+- Arch Linux (kernel 5.9)
 
 - Linux Mint 20 (Linux Mint based on Ubuntu) (kernel 5.4)
 - Linux Mint 19.3 (Linux Mint based on Ubuntu) (kernel 5.4)
+
+- LMDE 4 (Linux Mint based on Debian) (kernel 4.19)
 
 - Ubuntu 20.10 (kernel 5.8)
 - Ubuntu 20.04 (kernel 5.4)
 - Ubuntu 18.04 (kernel 5.4)
 
+- Raspberry Pi OS (12-02-2020) (ARM 32 bit) (kernel 5.4)
+
 ### Download Locations for Tested Linux Distributions:
 
+- Arch Linux - https://www.archlinux.org/
+- Linux Mint - https://www.linuxmint.com/
 - Raspberry Pi OS - https://www.raspberrypi.org/
-- Linux Mint - https://linuxmint.com/
-- Ubuntu - https://ubuntu.com/
+- Ubuntu - https://www.ubuntu.com/
 
 ### Tested Hardware:
 
@@ -98,11 +102,9 @@ Note: Some adapter makers change the chipsets in their products while keeping th
 
 The installation instructions that are provided are for the novice user. Experienced users are welcome to alter the installation to meet their needs.
 
-The installation instructions require that your system has access to the internet. There are numerous ways to enable temporary internet access depending on your hardware and situation. One method is to use tethering from a phone. Another method is to keep an ultra cheap adapter in your toolkit that uses an in-kernel (plug and play) driver. Here is one:
-```
-https://www.canakit.com/raspberry-pi-wifi.html
-```
-The installation instructions require the use of the terminal. The quick way to open a terminal: Ctrl+Alt+T (hold down on the Ctrl and Alt keys then press the T key.)
+The installation instructions require that your system has access to the internet. There are numerous ways to enable temporary internet access depending on your hardware and situation. One method is to use tethering from a phone. Another method is to keep an ultra cheap adapter in your toolkit that uses an in-kernel (plug and play) driver. Here is one: https://www.canakit.com/raspberry-pi-wifi.html.
+
+The installation instructions require the use of the terminal. The quick way to open a terminal: Ctrl+Alt+T (hold down on the Ctrl and Alt keys then press the T key).
 
 The installation instructions make use of DKMS. DKMS is a system utility which will automatically recompile and install this kernel module when a new kernel is installed. DKMS is provided by and maintained by Dell.
 
@@ -113,43 +115,43 @@ It is recommended that you do not delete the driver directory after installation
 Step 1: Open a terminal (Ctrl+Alt+T)
 
 Step 2: Update the system:
-```
+```bash
 $ sudo apt-get update
 ```
-Step 3: Install the required packages: (select the option for the OS you are using)
+Step 3: Install the required packages (select the option for the OS you are using):
 
 Option for Raspberry Pi OS:
-```
+```bash
 $ sudo apt-get install -y raspberrypi-kernel-headers bc build-essential dkms git
 ```
 Option for LMDE (Debian based):
-```
+```bash
 $ sudo apt-get install -y linux-headers-$(uname -r) build-essential dkms git
 ```
 Option for Linux Mint (Ubuntu based) or Ubuntu (all flavors):
-```
+```bash
 $ sudo apt-get install -y dkms git
 ```
-Option for Manjaro:
-```
+Option for Arch-based distributions (like Manjaro):
+```bash
 $ sudo pacman -S --noconfirm linux-headers dkms git
 ```
 Step 4: Create a directory to hold the downloaded driver:
 
 Note: The technique used in this document is to create a directory in the home directory called `src`.
-```
+```bash
 $ mkdir src
 ```
 Step 5: Move to the newly created directory:
-```
+```bash
 $ cd ~/src
 ```
 Step 6: Download the driver:
-```
+```bash
 $ git clone https://github.com/morrownr/88x2bu.git
 ```
 Step 7: Move to the newly created driver directory:
-```
+```bash
 $ cd ~/src/88x2bu
 ```
 Step 8: Run a preparation script if needed:
@@ -157,21 +159,21 @@ Step 8: Run a preparation script if needed:
 The Raspberry Pi OS requires a preparation script.
 
 For 32 bit Raspberry Pi OS: (Please skip this step if you are not installing to Raspberry Pi 32 bit)
-```
+```bash
 $ sudo ./raspi32.sh
 
 ```
 For 64 bit Raspberry Pi OS: (Please skip this step if you are not installing to Raspberry Pi 64 bit)
-```
+```bash
 $ sudo ./raspi64.sh
 
 ```
 Step 9: Run the installation script:
-```
+```bash
 $ sudo ./install-driver.sh
 ```
 Step 10: Reboot:
-```
+```bash
 $ sudo reboot
 ```
 ### Removal of the Driver:
@@ -179,15 +181,15 @@ $ sudo reboot
 Step 1: Open a terminal (Ctrl+Alt+T)
 
 Step 2: Move to the driver directory:
-```
+```bash
 $ cd ~/src/88x2bu
 ```
 Step 3: Run the removal script:
-```
+```bash
 $ sudo ./remove-driver.sh
 ```
 Step 4: Reboot:
-```
+```bash
 $ sudo reboot
 ```
 ### Driver Options:
@@ -203,11 +205,11 @@ To change the driver options, there are two options:
 Option 1: Edit `88x2bu.conf` with a text editor using a terminal interface.
 
 Example:
-```
+```bash
 $ sudo nano /etc/modprobe.d/88x2bu.conf
 ```
 Option 2: From the driver directory, run the `./edit-options.sh` script:
-```
+```bash
 $ sudo ./edit-options.sh
 ```
 The driver options are as follows:
@@ -278,7 +280,7 @@ USB 3 support is off by default as there can be problems with older USB 3 ports,
 
 See what your USB mode is:
 
-```
+```bash
 $ lsusb -t
 ```
 ```
@@ -316,7 +318,7 @@ EDUP EP-AC1605GS WiFi Adapter
 ### Steps:
 -----
 Optional: Disable Raspberry Pi onboard WiFi:
-```
+```bash
 $ sudo nano /boot/config.txt
 ```
 Add:
@@ -325,7 +327,7 @@ dtoverlay=disable-wifi
 ```
 -----
 Driver options:
-```
+```bash
 $ sudo nano /etc/modprobe.d/88x2bu.conf
 ```
 ```
@@ -334,42 +336,42 @@ rtw_switch_usb_mode=1
 ```
 -----
 Update system:
-```
+```bash
 $ sudo apt-get update
 $ sudo apt-get upgrade
 ```
 -----
 Install needed packages:
-```
+```bash
 $ sudo apt install hostapd bridge-utils
 ```
 -----
 Reboot system:
-```
+```bash
 $ sudo reboot
 ```
 -----
 Determine wireless interface:
-```
+```bash
 $ iw dev
 ```
 Note: The output shows the WiFi interface name and the current mode among other things. The interface name may be something like `wlx00c0cafre8ba` and is required below. The interface name `wlan0` will be used in the instructions below but you need to substitute your interface name.
 
 -----
-```
+```bash
 $ sudo nano /etc/dhcpcd.conf
 ```
 Add to bottom of file:
 ```
 denyinterfaces wlan0
-denyinterfaces eth0	
+denyinterfaces eth0
 ```
 -----
-```
+```bash
 $ sudo brctl addbr br0
 ```
 -----
-```
+```bash
 $ sudo nano /etc/network/interfaces
 ```
 Add:
@@ -380,7 +382,7 @@ iface br0 inet dhcp
 bridge_ports eth0 wlan0
 ```
 -----
-```
+```bash
 $ sudo nano /etc/hostapd/hostapd.conf
 ```
 Add:
@@ -417,7 +419,7 @@ vht_oper_centr_freq_seg0_idx=42
 Note: See 88x2bu/hostapd/hostapd.conf for detailed information regarding this configuration file.
 ```
 -----
-```
+```bash
 $ sudo nano /etc/default/hostapd
 ```
 
@@ -426,64 +428,64 @@ Update the line #DAEMON_CONF to: (remove #)
 DAEMON_CONF="/etc/hostapd/hostapd.conf"
 ```
 -----
-```
+```bash
 $ sudo systemctl unmask hostapd
 ```
-```
+```bash
 $ sudo systemctl enable hostapd
 ```
-```
+```bash
 $ sudo reboot
 ```
 
 ### Entering Monitor Mode with 'iw' and 'ip':
 
 Start by making sure the system recognizes the WiFi interface:
-```
+```bash
 $ sudo iw dev
 ```
 
 Note: The output shows the WiFi interface name and the current mode among other things. The interface name may be something like `wlx00c0cafre8ba` and is required for the below commands. The interface name `wlan0` will be used in the instructions below but you need to substitute your interface name.
 
 Take the interface down:
-```
+```bash
 $ sudo ip link set wlan0 down
 ```
 
 Set monitor mode:
-```
+```bash
 $ sudo iw wlan0 set monitor control
 ```
 
 Bring the interface up:
-```
+```bash
 $ sudo ip link set wlan0 up
 ```
 
 Verify the mode has changed:
-```
+```bash
 $ sudo iw dev
 ```
 
 ### Reverting to Managed Mode with 'iw' and 'ip':
 
 Take the interface down:
-```
+```bash
 $ sudo ip link set wlan0 down
 ```
 
 Set managed mode:
-```
+```bash
 $ sudo iw wlan0 set type managed
 ```
 
 Bring the interface up:
-```
+```bash
 $ sudo ip link set wlan0 up
 ```
 
 Verify the mode has changed:
-```
+```bash
 $ sudo iw dev
 ```
 
@@ -501,7 +503,7 @@ dtoverlay=disable-wifi
 ### How to forget a saved WiFi network on a Raspberry Pi
 
 1. Edit wpa_supplicant.conf:
-```
+```bash
 $ sudo nano /etc/wpa_supplicant/wpa_supplicant.conf
 ```
 2. Delete the relevant WiFi network block (including the 'network=' and opening/closing braces.
@@ -535,7 +537,7 @@ After making these changes, reboot the router.
 ### Set regulatory domain to correct setting in OS:
 
 Check the current setting:
-```
+```bash
 $ sudo iw reg get
 ```
 
@@ -544,13 +546,13 @@ If you get 00, that is the default and may not provide optimal performance.
 Find the correct setting here: http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 
 Set it temporarily:
-```
+```bash
 $ sudo iw reg set US
 ```
-Note: Substitute your country code if not the United States.
+Note: Substitute your country code if you are not in the United States.
 
 Set it permanently:
-```
+```bash
 $ sudo nano /etc/default/crda
 
 Change the last line to read:

--- a/remove-driver.sh
+++ b/remove-driver.sh
@@ -2,23 +2,24 @@
 
 DRV_NAME=rtl88x2bu
 DRV_VERSION=5.8.7.4
+KERNEL_VERSION=$(uname -r)
 OPTIONS_FILE=88x2bu.conf
 SCRIPT_NAME=remove-driver.sh
 
 if [[ $EUID -ne 0 ]]; then
-	echo "You must run this installation script with superuser priviliges."
+	echo "You must run this removal script with root privileges."
 	echo "Try \"sudo ./${SCRIPT_NAME}\""
 	exit 1
 fi
 
-dkms remove ${DRV_NAME}/${DRV_VERSION} --all
+dkms remove -m ${DRV_NAME} -v ${DRV_VERSION} -k ${KERNEL_VERSION}
 RESULT=$?
 
 if [[ "$RESULT" != "0" ]]; then
-	echo "An error occurred while running ${SCRIPT_NAME} : $RESULT "
+	echo "An error occurred while running: dkms remove -m ${DRV_NAME} -v ${DRV_VERSION} -k ${KERNEL_VERSION}"
 	exit $RESULT
 else
 	rm -f /etc/modprobe.d/${OPTIONS_FILE}
 	rm -rf /usr/src/${DRV_NAME}-${DRV_VERSION}
-	echo "${SCRIPT_NAME} was successful."
+	echo "The module has been removed successfully."
 fi


### PR DESCRIPTION
Hi! I've done some research and I found that in order to support different kernel versions on the same machine the option `-v ${KERNEL_VERSION}` has to be added to the `dkms` commands. When I switched to another kernel and ran `install-driver.sh`, `dkms add` exited with return code 3, for the module was already in its tree, but I thought that was not a problem, because even if it was already there, it would have to be built again anyway, against the current kernel headers, so I modified the script to continue the execution in that case. I've also added Arch Linux as a tested distribution, I've added the kernel versions I tested and the Arch website. Finally, I've added `bash` as the code language where it was needed, in order to enable the syntax highlighting. If you don't like it, you can remove it.
I think the driver removal is up to you, if you like to remove it for all the kernels, you can keep using the option `--all`, otherwise the option `-v ${KERNEL_VERSION}` has to be added in `remove-driver.sh`, too.
What do you think? 