### PR TITLE
Support source driver directory with spaces

### DIFF
--- a/install-driver.sh
+++ b/install-driver.sh
@@ -23,7 +23,7 @@ else
 fi
 
 echo "Copying source files to: /usr/src/${DRV_NAME}-${DRV_VERSION}"
-cp -r ${DRV_DIR} /usr/src/${DRV_NAME}-${DRV_VERSION}
+cp -r "${DRV_DIR}" /usr/src/${DRV_NAME}-${DRV_VERSION}
 
 echo "Copying ${OPTIONS_FILE} to: /etc/modprobe.d"
 cp -r ${OPTIONS_FILE} /etc/modprobe.d


### PR DESCRIPTION
If the source driver directory (stored in DRV_DIR) contains spaces, the cp command should reference it within double quotes, otherwise the command fails.